### PR TITLE
Use string IDs for models maintained in PM memory

### DIFF
--- a/models/action.json
+++ b/models/action.json
@@ -3,6 +3,10 @@
   "base": "PersistedModel",
   "description": "Represents an action to perform on an instance",
   "properties": {
+    "id": {
+      "type": "string",
+      "id": true
+    },
     "request": {
       "type": "object",
       "required": true,
@@ -15,11 +19,16 @@
     "result": {
       "type": "object",
       "description": "The result or output of the action"
+    },
+    "serviceInstanceId": {
+      "type": "number",
+      "description": "Foreign key for associated ServiceInstance",      
+      "required": true
     }
   },
   "validations": [],
   "relations": {
-    "instance": {
+    "serviceInstance": {
       "type": "belongsTo",
       "model": "ServiceInstance"
     }

--- a/models/profile-data.js
+++ b/models/profile-data.js
@@ -1,0 +1,11 @@
+var uuid = require('uuid');
+
+module.exports = function(ProfileData) {
+  ProfileData.beforeCreate = function(next) {
+    // Generate a unique ID for this process
+    var profileId = uuid.v4();
+
+    this.id = this.id || profileId;
+    next();
+  };
+};

--- a/models/profile-data.json
+++ b/models/profile-data.json
@@ -4,6 +4,11 @@
   "base": "PersistedModel",
   "description": "Represents a cpu profile or heap dump gathered from a node process",
   "properties": {
+    "id": {
+      "type": "string",
+      "index": true,
+      "id": true
+    },
     "executorId": {
       "type": "number",
       "index": 1,
@@ -14,7 +19,7 @@
       "index": 1,
       "description": "The ID if the Service the process was running"
     },
-    "instanceId": {
+    "serviceInstanceId": {
       "type": "number",
       "index": 1,
       "description": "The ID if the Service instance the process was part of"
@@ -52,6 +57,10 @@
     "hidden": ["executorId"]
   },
   "relations": {
+    "serviceProcess": {
+      "type": "belongsTo",
+      "model": "ServiceProcess"
+    },
     "executor": {
       "type": "belongsTo",
       "model": "Executor"
@@ -59,6 +68,10 @@
     "serverService": {
       "type": "belongsTo",
       "model": "ServerService"
+    },
+    "serviceInstance": {
+      "type": "belongsTo",
+      "model": "ServiceInstance"
     }
   },
   "acls": []

--- a/models/service-instance.js
+++ b/models/service-instance.js
@@ -1,0 +1,11 @@
+module.exports = function(ServiceInstance) {
+  ServiceInstance.remoteMethod('downloadProfile',
+    {
+      isStatic: false,
+      http: {path: '/profileDatas/:profileId/download', verb: 'get'},
+      accepts: [
+        {arg: 'ctx', http: {source: 'context'}}
+      ],
+      description: 'Download service profiling information'
+    });
+}

--- a/models/service-instance.json
+++ b/models/service-instance.json
@@ -69,9 +69,6 @@
       "description": "The version of strong-agent running on this instance"
     }
   },
-  "options": {
-    "hidden": ["executorId"]
-  },
   "relations": {
     "actions": {
       "type": "hasMany",
@@ -81,6 +78,10 @@
       "type": "hasMany",
       "model": "ServiceProcess"
     },
+    "metrics": {
+      "type": "hasMany",
+      "model": "ServiceMetric"
+    },
     "executor": {
       "type": "belongsTo",
       "model": "Executor"
@@ -88,6 +89,11 @@
     "serverService": {
       "type": "belongsTo",
       "model": "ServerService"
+    },
+    "profileDatas": {
+      "type": "hasMany",
+      "model": "ProfileData",
+      "description": "List of cpuprofile or heapdumps gathered for this service"
     }
   },
   "acls": []

--- a/models/service-metric.json
+++ b/models/service-metric.json
@@ -3,7 +3,7 @@
   "base": "PersistedModel",
   "properties": {
     "processId": {
-      "type": "number",
+      "type": "string",
       "description": "id of ServiceProcess, not the pid",
       "required": true
     },
@@ -26,7 +26,12 @@
     }
   },
   "validations": [],
-  "relations": {},
+  "relations": {
+    "serviceInstance": {
+      "type": "belongsTo",
+      "model": "ServiceInstance"
+    }
+  },
   "acls": [],
   "methods": []
 }

--- a/models/service-process.js
+++ b/models/service-process.js
@@ -1,0 +1,11 @@
+var uuid = require('uuid');
+
+module.exports = function(ServiceProcess) {
+  ServiceProcess.beforeCreate = function(next) {
+    // Generate a unique ID for this process
+    var procId = uuid.v4();
+
+    this.id = this.id || procId;
+    next();
+  };
+};

--- a/models/service-process.json
+++ b/models/service-process.json
@@ -3,6 +3,11 @@
   "base": "PersistedModel",
   "description": "Represents a since OS process running on the Instance",
   "properties": {
+    "id": {
+      "type": "string",
+      "index": true,
+      "id": true
+    },
     "parentPid": {
       "type": "number",
       "required": true,

--- a/models/service.js
+++ b/models/service.js
@@ -27,15 +27,6 @@ module.exports = function(Service) {
       accepts: {arg: 'ctx', http: {source: 'context'}}
     });
 
-    this.remoteMethod('downloadProfile', {
-      isStatic: false,
-      http: {path: '/profileDatas/:profileId/download', verb: 'get'},
-      accepts: [
-        {arg: 'ctx', http: {source: 'context'}}
-      ],
-      description: 'Download service profiling information'
-    });
-
     this.disableRemoteMethod('__delete__actions');
     this.disableRemoteMethod('__destroyById__actions');
     this.disableRemoteMethod('__updateById__actions');

--- a/models/service.json
+++ b/models/service.json
@@ -42,11 +42,6 @@
       "model": "ServiceInstance",
       "description": "List of instances that run this service"
     },
-    "profileDatas": {
-      "type": "hasMany",
-      "model": "ProfileData",
-      "description": "List of cpuprofile or heapdumps gathered for this service"
-    },
     "groups": {
       "type": "embedsMany",
       "model": "Group",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strong-mesh-models",
-  "version": "3.0.1",
+  "version": "4.0.0",
   "description": "Loopback models for communicating over REST with strong-pm and strong-scheduler",
   "keywords": [
     "StrongLoop",

--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
     "loopback-boot": "^2.0.0",
     "serve-favicon": "^2.1.5",
     "tap": "^0.4.13"
+  },
+  "dependencies": {
+    "uuid": "^2.0.1"
   }
 }


### PR DESCRIPTION
Ensures that there are no ID conflicts when collecting data from multiple PMs and processing them in mesh API. Also allows for consistent access to models related to the Instance.

* Change Action, ProfileData, ServiceProcess models to have string ID
* Create String IDs instead of using autogenerated numeric IDs
* Make foreign keys to ServiceInsance consistent (serviceInstanceId)
* Add relation between ServiceProcess and ProfileData
* Add relation between ServiceMetric and ServiceInstance