### PR TITLE
Add support for Express Usage records

### DIFF
--- a/models/express-usage-record.json
+++ b/models/express-usage-record.json
@@ -15,16 +15,7 @@
       "type": "date",
       "required": true
     },
-    "client": {
-      "type": "object"
-    },
-    "request": {
-      "type": "object"
-    },
-    "response": {
-      "type": "object"
-    },
-    "data": {
+    "usage": {
       "type": "object"
     }
   },

--- a/models/express-usage-record.json
+++ b/models/express-usage-record.json
@@ -1,0 +1,35 @@
+{
+  "name": "ExpressUsageRecord",
+  "base": "PersistedModel",
+  "properties": {
+    "processId": {
+      "type": "number",
+      "description": "id of ServiceProcess, not the pid",
+      "required": true
+    },
+    "workerId": {
+      "type": "number",
+      "required": true
+    },
+    "timestamp": {
+      "type": "date",
+      "required": true
+    },
+    "client": {
+      "type": "object"
+    },
+    "request": {
+      "type": "object"
+    },
+    "response": {
+      "type": "object"
+    },
+    "data": {
+      "type": "object"
+    }
+  },
+  "validations": [],
+  "relations": {},
+  "acls": [],
+  "methods": []
+}

--- a/test/app/model-config.json
+++ b/test/app/model-config.json
@@ -51,5 +51,9 @@
   "InstanceAction": {
     "dataSource": "db",
     "public": false
+  },
+  "ExpressUsageRecord": {
+    "dataSource": "db",
+    "public": false
   }
 }


### PR DESCRIPTION
When the supervised express-base application has strong-express-metrics configured, strong-agent and strong-supervisor will forward usage records which will be stored in the ExpressUsageRecord model.

Connect to strongloop/strong-pm#125
