### PR TITLE
Add Service methods for setting/unsetting environment variables

### DIFF
--- a/common/models/service.js
+++ b/common/models/service.js
@@ -30,6 +30,27 @@ module.exports = function(Service) {
       description: 'Deploy service'
     });
 
+    this.remoteMethod('setEnv', {
+      isStatic: false,
+      http: {path: '/env/:name', verb: 'put'},
+      accepts: [
+        {arg: 'name', type: 'string', http: {source: 'path'}},
+        {arg: 'value', required: true, type: 'string', http: {source: 'body'}}
+      ],
+      returns: {arg: 'value', type: 'string'},
+      description: 'Get/Set/Delete Environment Variables'
+    });
+
+    this.remoteMethod('unsetEnv', {
+      isStatic: false,
+      http: {path: '/env/:name', verb: 'delete'},
+      accepts: [
+        {arg: 'name', required: true, type: 'string', http: {source: 'path'}},
+      ],
+      returns: {arg: 'value', type: 'string'},
+      description: 'Unset Environment Variables'
+    });
+
     this.remoteMethod('getPack', {
       isStatic: false,
       http: [

--- a/common/models/service.json
+++ b/common/models/service.json
@@ -40,6 +40,7 @@
     },
     "env": {
       "type": "object",
+      "default": {},
       "description": "List of environment variables set for the node application"
     }
   },

--- a/server/models/server-service.js
+++ b/server/models/server-service.js
@@ -115,4 +115,20 @@ module.exports = function(ServerService) {
     ServerService.app.serviceManager.getDeployment(this, ctx.req, ctx.res);
   }
   ServerService.prototype.getPack = getPack;
+
+  function setEnv(name, value, callback) {
+    this.env = this.env || {};
+    this.env[name] = value;
+    debug('setEnv(%j, %j)', name, value);
+    this.save(callback);
+  }
+  ServerService.prototype.setEnv = setEnv;
+
+  function unsetEnv(name, callback) {
+    this.env = this.env || {};
+    debug('unsetEnv(%s) [%j]', name, this.env[name]);
+    delete this.env[name];
+    this.save(callback);
+  }
+  ServerService.prototype.unsetEnv = unsetEnv;
 };

--- a/test/test-service-create-destroy.js
+++ b/test/test-service-create-destroy.js
@@ -37,6 +37,7 @@ test('Create and destroy a service', function(t) {
       t.equal(service.name, 'My Service', 'Service name should match');
       t.equal(service._groups.length, 1, 'Service should have 1 group');
       t.equal(service._groups[0].scale, 2, 'Group scale should be 2');
+      t.deepEqual(service.env, {}, 'Environment is empty by default');
       client.serviceDestroy('My Service', function(err) {
         t.ok(!err, 'Service should be destroyed');
         server.stop();

--- a/test/test-service-env.js
+++ b/test/test-service-env.js
@@ -1,0 +1,78 @@
+var Client = require('../index').Client;
+var meshServer = require('../index').meshServer;
+var ServiceManager = require('../index').ServiceManager;
+var test = require('tap').test;
+
+test('Service environment variable manipulation', function(t) {
+  var manager = new ServiceManager();
+  var server = meshServer(manager);
+
+  var client = null;
+  var service = null;
+  var Service = null;
+
+  t.test('server & client setup', function(tt) {
+    server.start(function onStart(err, port) {
+      tt.ifError(err, 'server started successfully');
+      client = new Client('http://127.0.0.1:' + port + '/api');
+      Service = client.models.ServerService;
+      tt.end();
+    });
+  });
+
+  t.test('service creation', function(tt) {
+    Service.create({name: 'test'}, function onCreate(err, newService) {
+      service = newService;
+      tt.ifError(err, 'service instance created successfully');
+      tt.deepEqual(service.env, {}, 'Initial environment is empty');
+      tt.end();
+    });
+  });
+
+  t.test('setEnv sets a single environment variable', function(tt) {
+    tt.deepEqual(service.env, {}, 'precondition');
+    service.setEnv('FOO', 'BAR', function(err, res) {
+      tt.ifError(err, 'setEnv (1) succeeded');
+      tt.deepEqual(res.env, {FOO: 'BAR'}, 'setEnv tells us the new state');
+      service.setEnv('ALSO', 'and then', function(err, res) {
+        tt.ifError(err, 'setEnv (2) succeeded');
+        tt.deepEqual(res.env, {ALSO: 'and then', FOO: 'BAR'}, 'multiple calls');
+        tt.end();
+      });
+    });
+  });
+
+  t.test('setEnv change is persisted', function(tt) {
+    Service.findOne(service.id, function onReload(err, updatedInstance) {
+      tt.ifError(err, 'reload succeeded');
+      service = updatedInstance;
+      tt.deepEqual(service.env, {ALSO: 'and then', FOO: 'BAR'}, 'persisted');
+      tt.end();
+    });
+  });
+
+  t.test('unsetEnv deletes a single environment variable', function(tt) {
+    tt.deepEqual(service.env, {ALSO: 'and then', FOO: 'BAR'}, 'precondition');
+    service.unsetEnv('FOO', function(err, res) {
+      tt.ifError(err, 'unsetEnv succeeded');
+      tt.deepEqual(res.env, {ALSO: 'and then'}, 'Environment is updated');
+      tt.end();
+    });
+  });
+
+  t.test('setEnv change is persisted', function(tt) {
+    Service.findOne(service.id, function onReload(err, updatedInstance) {
+      tt.ifError(err, 'reload succeeded');
+      service = updatedInstance;
+      tt.deepEqual(service.env, {ALSO: 'and then'}, 'persisted');
+      tt.end();
+    });
+  });
+
+  t.test('client & server shutdown', function(tt) {
+    server.stop();
+    tt.end();
+  });
+
+  t.end();
+});


### PR DESCRIPTION
Adds PUT and DELETE handlers for /Services/:id/env/:name to set/unset individual environment variables so that API callers don't need to fetch/modify/put the entire environment object just to make a single change.

Based on #19, so most of the commits are from there.

Connected to strongloop/strong-pm#48