### PR TITLE
Fix recording of express metric timestamp

### DIFF
--- a/server/models/express-usage-record.js
+++ b/server/models/express-usage-record.js
@@ -24,7 +24,7 @@ module.exports = function extendExpressUsageRecord(ExpressUsageRecord) {
       var usageRecord = {
         processId: proc.id,
         workerId: proc.workerId,
-        timeStamp: record.timeStamp,
+        timeStamp: record.timestamp,
         detail: record
       };
 

--- a/test/test-notification-model-updates.js
+++ b/test/test-notification-model-updates.js
@@ -320,7 +320,7 @@ test('Test notifications', function(t) {
 
   function notifyExpressRecord(dateBy, tt) {
     var rec = {
-      timeStamp: Date.now() - dateBy,
+      timestamp: Date.now() - dateBy,
       client: {address: '::1'},
       request: {method: 'GET', url: '/'},
       response: {status: 404, duration: 6},


### PR DESCRIPTION
Record coming from strong-express-metric module use `timestamp` instead
of `timeStamp`.