### PR TITLE
server: persist instance.cpus to trigger resize

### DIFF
--- a/bin/sl-meshctl.js
+++ b/bin/sl-meshctl.js
@@ -387,12 +387,13 @@ function cmdRollingRestart(client) {
 function cmdSetClusterSize(client) {
   var targetService = mandatory('service');
   var size = mandatory('size');
+  var persist = false;
 
   client.serviceFind(targetService, function(err, service) {
     dieIf(err);
     service.setClusterSize(
       size,
-      false,
+      persist,
       printResponse.bind(null, service, null)
     );
   });

--- a/common/models/service-instance.json
+++ b/common/models/service-instance.json
@@ -53,7 +53,6 @@
     },
     "cpus": {
       "type": "string",
-      "default": "cpus",
       "description": "The number of cpus to use when starting the service on this instance"
     },
     "applicationName": {


### PR DESCRIPTION
Only the set-size command was actually changing a running instance's
size. Updates to the size were being notified as onInstanceUpdate to pm,
but it wouldn't apply them to the running instance (doing so requires
sending a set-size command).

Now, if you don't want persistence, a set-size command is sent, which is
non-persistent.

If you do want persistence, the model is updated, that update goes to
pm, which then updates both the instance sl-run CLI options AND sends a
set-size command to a running instance (if size has changed). Because of
this, the persistent branch that sends set-size is no longer necessary.

Also, some effort was being made to capture non-numeric values for cpus,
and turn them into some default value. This code is confusing and
unused, its now gone. The size can be set to whatever is wanted (whether
that size has any effect on strong-cluster-control is a different
matter).

Probably, validation should occur, but that doesn't happen right now.

connected to strongloop-internal/scrum-nodeops#537