### PR TITLE
meshctl: fix message splitting

### DIFF
--- a/bin/sl-meshctl.js
+++ b/bin/sl-meshctl.js
@@ -730,11 +730,11 @@ function dieIf(err) {
   //   User already exists (value: 'admin'); `email` Email already exists
   //   (value: 'ignore@me.com').
   // Split into first line, and the rest.
-  var msgs = msg.split('.');
+  var msgs = msg.split('. ');
 
   console.error('Command %j failed with %s', command, msgs.shift());
   if (msgs.length) {
-    console.error('%s', msgs.join('.').trim());
+    console.error('%s', msgs.join('. ').trim());
   }
   process.exit(1);
 }


### PR DESCRIPTION
`slc ctl -C http://no-such.com` was triggering the message splitting in
the middle of the host name, so split only on '. ', which is what
loopback uses for long errors.