### PR TITLE
client: implement checkRemoteApiSemver()

### DIFF
--- a/bin/sl-meshctl.js
+++ b/bin/sl-meshctl.js
@@ -90,11 +90,15 @@ if (process.env.SSH_KEY) {
 
 maybeTunnel(apiUrl, sshOpts, function(err, apiUrl) {
   dieIf(err);
-  runCommand(apiUrl, command);
+  var client = new Client(apiUrl);
+
+  client.checkRemoteApiSemver(function(err) {
+    dieIf(err);
+    runCommand(client, command);
+  });
 });
 
-function runCommand(apiUrl, command) {
-  var client = new Client(apiUrl);
+function runCommand(client, command) {
   ({
     'create': cmdCreateService,
     'remove': cmdRemoveService,

--- a/test/test-client-version-match.js
+++ b/test/test-client-version-match.js
@@ -1,0 +1,33 @@
+var Client = require('../index').Client;
+var meshServer = require('../index').meshServer;
+var ServiceManager = require('../index').ServiceManager;
+var test = require('tap').test;
+
+var manager = new ServiceManager();
+var apiVersion;
+
+manager.getApiVersionInfo = function(callback) {
+  setImmediate(function() {
+    callback(null, {
+      apiVersion: apiVersion,
+    });
+  });
+};
+
+var server = meshServer(manager);
+server.set('port', 0);
+
+test('check non-matching version', function(tt) {
+  apiVersion = require('../package').version;
+
+  server.start(function onStart(err, port) {
+    tt.ifError(err, 'server started successfully');
+    var client = new Client('http://127.0.0.1:' + port + '/api');
+    client.checkRemoteApiSemver(function(err) {
+      tt.ifError(err, 'should not error');
+      server.stop(function() {
+        tt.end();
+      });
+    });
+  });
+});

--- a/test/test-client-version-mismatch.js
+++ b/test/test-client-version-mismatch.js
@@ -1,0 +1,34 @@
+var Client = require('../index').Client;
+var meshServer = require('../index').meshServer;
+var ServiceManager = require('../index').ServiceManager;
+var test = require('tap').test;
+
+var manager = new ServiceManager();
+var apiVersion;
+
+manager.getApiVersionInfo = function(callback) {
+  setImmediate(function() {
+    callback(null, {
+      apiVersion: apiVersion,
+    });
+  });
+};
+
+var server = meshServer(manager);
+server.set('port', 0);
+
+test('check non-matching version', function(tt) {
+  apiVersion = '5.1.1-something';
+
+  server.start(function onStart(err, port) {
+    tt.ifError(err, 'server started successfully');
+    var client = new Client('http://127.0.0.1:' + port + '/api');
+    client.checkRemoteApiSemver(function(err) {
+      tt.assert(err, 'should mismatch');
+      tt.assert(/incompatible.*5.1.1/.test(err.message), err.message);
+      server.stop(function() {
+        tt.end();
+      });
+    });
+  });
+});


### PR DESCRIPTION
Checks whether the remote API version is major-compatible with the
client's API version.

connected to strongloop-internal/scrum-nodeops#544
connected to strongloop-internal/scrum-nodeops#545