### PR TITLE
Add setEnvs remote method to Service model

### DIFF
--- a/common/models/service.js
+++ b/common/models/service.js
@@ -41,6 +41,22 @@ module.exports = function(Service) {
       description: 'Set environment variables'
     });
 
+    this.remoteMethod('setEnvs', {
+      isStatic: false,
+      http: {path: '/env/', verb: 'put'},
+      accepts: [{
+        arg: 'env',
+        required: true,
+        type: 'object',
+        http: {source: 'body'},
+        root: true,
+        description: 'Key-value describing environment variables to add. ' +
+          'A null value causes the variable to be removed',
+      }],
+      returns: {arg: 'env', type: 'object'},
+      description: 'Set multiple environment variables.'
+    });
+
     this.remoteMethod('unsetEnv', {
       isStatic: false,
       http: {path: '/env/:name', verb: 'delete'},

--- a/server/models/server-service.js
+++ b/server/models/server-service.js
@@ -135,6 +135,22 @@ module.exports = function extendServerService(ServerService) {
   }
   ServerService.prototype.setEnv = setEnv;
 
+  function setEnvs(envUpd, callback) {
+    debug('setEnvs(%j)', envUpd);
+    this.env = this.env || {};
+    for (var k in envUpd) {
+      if (!envUpd.hasOwnProperty(k)) continue;
+        if (!envUpd[k])
+          delete this.env[k];
+      else
+        this.env[k] = envUpd[k];
+    }
+    this.save(function(err, res) {
+      callback(err, res && res.env);
+    });
+  }
+  ServerService.prototype.setEnvs = setEnvs;
+
   function unsetEnv(name, callback) {
     this.env = this.env || {};
     debug('unsetEnv(%s) [%j]', name, this.env[name]);

--- a/test/test-meshctl-env.js
+++ b/test/test-meshctl-env.js
@@ -33,6 +33,14 @@ test('Test env commands', function(t) {
       });
     });
 
+    t.test('env-set API', function(tt) {
+      service.setEnvs({A: 1, B: 2}, function(err, response) {
+        tt.ifError(err, 'call should not error');
+        assert.deepEqual(response, {A: 1, B: 2});
+        tt.end();
+      });
+    });
+
     t.test('env-set CLI', function(tt) {
       exec.resetHome();
       exec(port, 'env-set A=1 B=2', function(err, stdout) {


### PR DESCRIPTION
Back ported from master/6.x

I'd like to release this as 5.1.0 so that strongloop/strong-arc#1226 can be simplified to use the same API it will use when strong-mesh-client is upgraded to use strong-mesh-models@6.

/cc @jtary 