### PR TITLE
Properly revive processes on fork

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "lint": "eslint . && jscs .",
     "pretest": "eslint . && jscs .",
-    "test": "tap --tap --stdout --stderr --timeout=300 test/test-*.js",
+    "test": "tap --bail --timeout=300 test/test-*.js",
     "cover": "test/cover.sh"
   },
   "dependencies": {
@@ -53,7 +53,7 @@
     "eslint": "^0.20.0",
     "istanbul": "^0.3.0",
     "jscs": "^1.11.3",
-    "tap": "^0.7.0",
+    "tap": "^1.0.4",
     "temporary": "0.0.8"
   }
 }

--- a/test/test-deploy-endpoints.js
+++ b/test/test-deploy-endpoints.js
@@ -91,5 +91,7 @@ test('Create and destroy a service', function(t) {
     });
   });
 
-  t.end();
+  server.on('stopped', function() {
+    t.end();
+  });
 });

--- a/test/test-service-create-destroy.js
+++ b/test/test-service-create-destroy.js
@@ -26,7 +26,7 @@ test('Create and destroy a service', function(t) {
   }
   TestServiceManager.prototype.onServiceDestroy = onServiceDestroy;
 
-  t.plan(12);
+  t.plan(13);
   var server = meshServer(new TestServiceManager());
   server.set('port', 0);
   server.start(function(err, port) {


### PR DESCRIPTION
When upserting a ServiceProcess instance for a `fork` event, clear the `stopReason` and `stopTime` so that they are properly marked as running if they were previously marked as dead.

Also some small tweaks to some tests to work with an upgrade of tap.