### PR TITLE
Distinguish REST API and js API version

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -71,7 +71,7 @@ function Client(apiUrl, options) {
 
   this.loopback = client;
   this.models = client.models;
-  this.version = require('../package.json').version;
+  this.apiVersion = require('../package.json').apiVersion;
 
   // Populates the cache of models so you can access them with
   // client.models.ModelName.
@@ -104,10 +104,10 @@ function checkRemoteApiSemver(callback) {
       return callback();
     }
 
-    var localMajor = self.version.split('.')[0];
+    var localMajor = self.apiVersion.split('.')[0];
     var remoteMajor = info.apiVersion.split('.')[0];
 
-    debug('local %s %s.x remote %s %s.x', self.version, localMajor,
+    debug('local %s %s.x remote %s %s.x', self.apiVersion, localMajor,
           info.apiVersion, remoteMajor);
 
     if (localMajor !== remoteMajor) {

--- a/client/models/server-service.js
+++ b/client/models/server-service.js
@@ -60,7 +60,7 @@ module.exports = function extServerService(ServerService) {
 
   function getStatusSummary(callback) {
     var serviceInfo = {};
-    serviceInfo.clientApiVersion = require('../../package.json').version;
+    serviceInfo.clientApiVersion = require('../../package.json').apiVersion;
     serviceInfo.env = this.env;
     serviceInfo.name = this.name;
     serviceInfo.id = this.id;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "strong-mesh-models",
   "version": "7.0.0",
+  "apiVersion": "6.1.0",
   "description": "Loopback models for communicating over REST with strong-pm and strong-scheduler",
   "keywords": [
     "StrongLoop",

--- a/test/test-client-version-match.js
+++ b/test/test-client-version-match.js
@@ -18,7 +18,7 @@ var server = meshServer(manager);
 server.set('port', 0);
 
 test('check non-matching version', function(tt) {
-  apiVersion = require('../package').version;
+  apiVersion = require('../package.json').apiVersion;
 
   server.start(function onStart(err, port) {
     tt.ifError(err, 'server started successfully');

--- a/test/test-meshctl-version.js
+++ b/test/test-meshctl-version.js
@@ -1,6 +1,6 @@
 var exec = require('./exec-meshctl');
 var test = require('tap').test;
-var version = require('../package').version;
+var version = require('../package.json').version;
 
 test('Test help messages', function(t) {
   exec(0, '--version', function(err, version1) {


### PR DESCRIPTION
The package version is the semver for the js API used by packages that
require strong-mesh-models, the apiVersion is for the REST API.

connected to strongloop-internal/scrum-nodeops#610
