### PR TITLE
trace-object: records are stringified now

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -107,13 +107,12 @@ function server(serviceManager, minkelite, options) {
         AgentTrace.recordTrace(instanceId, uInfo, callback);
         break;
       case 'trace:object':
-        var traceVersion = uInfo.record.version;
-        var accountName = uInfo.record.packet.metadata.account_key;
         if (!app.minkelite)
           return callback();
-        app.minkelite.postRawPieces(traceVersion,
-          accountName,
-          uInfo.record.packet,
+        var record = JSON.parse(uInfo.record);
+        app.minkelite.postRawPieces(record.version,
+          record.packet.metadata.account_key,
+          record.packet,
           callback);
         break;
       case 'express:usage-record':

--- a/test/test-trace-client-api.js
+++ b/test/test-trace-client-api.js
@@ -70,14 +70,14 @@ test('Test trace client api', function(t) {
       /* eslint-disable camelcase */
       var notification = {
         cmd: 'trace:object',
-        record: {
+        record: JSON.stringify({
           version: '1.2.3',
           packet: {
             metadata: {
               account_key: 'key key key'
             }
           }
-        }
+        })
       };
       /* eslint-enable camelcase */
 

--- a/test/test-trace-disabled-client-api.js
+++ b/test/test-trace-disabled-client-api.js
@@ -20,14 +20,14 @@ test('Test trace client api (disabled trace)', function(t) {
       /* eslint-disable camelcase */
       var notification = {
         cmd: 'trace:object',
-        record: {
+        record: JSON.stringify({
           version: '1.2.3',
           packet: {
             metadata: {
               account_key: 'key key key'
             }
           }
-        }
+        })
       };
       /* eslint-enable camelcase */
 


### PR DESCRIPTION
strong-supervisor now emits the trace object record as a string, as a
performance optimization.

Refs: https://github.com/strongloop/strong-supervisor/pull/129

R=@sam-github