### PR TITLE
meshctl: assert instance is well-formed

### DIFF
--- a/bin/sl-meshctl.js
+++ b/bin/sl-meshctl.js
@@ -207,6 +207,9 @@ function printServiceStatus(service) {
     for (var i in summary.instances) {
       if (!summary.instances.hasOwnProperty(i)) continue;
       var inst = summary.instances[i];
+      assert(inst.version);
+      assert(inst.agentVersion);
+      assert(inst.clusterSize);
       instanceTable.push(['',
         inst.version, inst.agentVersion, inst.clusterSize
       ]);


### PR DESCRIPTION
Attempt to find source of this difficult to reproduce bug:

strong-mesh-models/node_modules/text-table/index.js:59
    return m ? m.index + 1 : c.length;
                              ^
TypeError: Cannot read property 'length' of null
    at dotindex (strong-mesh-models/node_modules/text-table/index.js:59:31)
    at strong-mesh-models/node_modules/text-table/index.js:11:21
    at Array.forEach (native)
    at forEach (strong-mesh-models/node_modules/text-table/index.js:73:31)
    at strong-mesh-models/node_modules/text-table/index.js:10:9
    at Array.reduce (native)
    at reduce (strong-mesh-models/node_modules/text-table/index.js:63:30)
    at module.exports (strong-mesh-models/node_modules/text-table/index.js:9:20)
    at strong-mesh-models/bin/sl-meshctl.js:214:35
    at strong-mesh-models/client/models/server-service.js:100:9