### PR TITLE
fix over aggressive assert

### DIFF
--- a/bin/sl-meshctl.js
+++ b/bin/sl-meshctl.js
@@ -207,9 +207,9 @@ function printServiceStatus(service) {
     for (var i in summary.instances) {
       if (!summary.instances.hasOwnProperty(i)) continue;
       var inst = summary.instances[i];
-      assert(inst.version);
-      assert(inst.agentVersion);
-      assert(inst.clusterSize);
+      assert('version' in inst);
+      assert('agentVersion' in inst);
+      assert('clusterSize' in inst);
       instanceTable.push(['',
         inst.version, inst.agentVersion, inst.clusterSize
       ]);


### PR DESCRIPTION
Asserts added in 94ef1e4 in #65 broke pmctl when accessing an instance
with cluster size of 0, which is the initial state for apps that are
dockerized by strong-pm.

This was causing strong-pm's pmctl tests fail for me.