### PR TITLE
Use only HTTP for control, not local sockets

### DIFF
--- a/bin/sl-meshctl.js
+++ b/bin/sl-meshctl.js
@@ -9,7 +9,6 @@ var concat = require('concat-stream');
 var debug = require('debug')('strong-mesh-models:meshctl');
 var fmt = require('util').format;
 var fs = require('fs');
-var home = require('osenv').home();
 var npmls = require('strong-npm-ls');
 var path = require('path');
 var table = require('text-table');
@@ -37,9 +36,6 @@ var parser = new Parser([
 
 var apiUrl = process.env.STRONGLOOP_MESH_API ||
   process.env.STRONGLOOP_PM ||
-  exists('pmctl') ||
-  exists(path.join(home, '.strong-pm', 'pmctl')) ||
-  exists('/var/lib/strong-pm/pmctl') ||
   'http://127.0.0.1:8701';
 
 var command = 'status';
@@ -737,11 +733,6 @@ function download(instance, profileId, file, callback) {
       }
     }
   });
-}
-
-function exists(path) {
-  if (fs.existsSync(path))
-    return path;
 }
 
 function mandatory(name) {

--- a/bin/sl-meshctl.txt
+++ b/bin/sl-meshctl.txt
@@ -10,11 +10,8 @@ Options:
 The control endpoint for the process manager is searched for if not specified,
 in this order:
 
-1. `STRONGLOOP_PM` in environment: may be a local domain path, or an HTTP URL.
-2. `./pmctl`: a process manager running in the current working directory.
-3. `~/.strong-pm/pmctl`: a process manager running in the user's home directory.
-4. `/var/lib/strong-pm/pmctl`: a process manager installed by pm-install.
-5. `http://localhost:8701`: a process manager running on localhost
+1. `STRONGLOOP_PM` in environment: an HTTP URL.
+2. `http://localhost:8701`: a process manager running on localhost
 
 An HTTP URL is mandatory for remote process managers, but can also be used on
 localhost. If the process manager is using HTTP authentication

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "loopback-boot": "^2.6.0",
     "loopback-datasource-juggler": "^2.18.0",
     "loopback-explorer": "^1.7.0",
-    "osenv": "^0.1.0",
     "posix-getopt": "^1.1.0",
     "request": "^2.53.0",
     "serve-favicon": "^2.2.0",


### PR DESCRIPTION
connected to strongloop-internal/scrum-nodeops#444