### PR TITLE
profile-data: support delete of ProfileData

### DIFF
--- a/common/models/service.js
+++ b/common/models/service.js
@@ -177,9 +177,7 @@ module.exports = function(Service) {
     this.disableRemoteMethod('__link__executors');
     this.disableRemoteMethod('__exists__executors');
 
-    this.disableRemoteMethod('__delete__profileDatas');
     this.disableRemoteMethod('__create__profileDatas');
-    this.disableRemoteMethod('__destroyById__profileDatas');
     this.disableRemoteMethod('__updateById__profileDatas');
 
     this.disableRemoteMethod('__delete__groups');

--- a/server/model-config.json
+++ b/server/model-config.json
@@ -64,7 +64,7 @@
   },
   "ProfileData": {
     "dataSource": "db",
-    "public": false
+    "public": true
   },
   "InstanceAction": {
     "dataSource": "db",

--- a/test/meshctl-helper.js
+++ b/test/meshctl-helper.js
@@ -2,7 +2,7 @@ var async = require('async');
 var meshServer = require('../index').meshServer;
 var Client = require('../index').Client;
 
-function testCmdHelper(t, TestServiceManager, test, MockMinkelite) {
+function testCmdHelper(t, TestServiceManager, callback, MockMinkelite) {
   var server = null;
   if (MockMinkelite) {
     server = meshServer(new TestServiceManager(), new MockMinkelite(), {});
@@ -110,7 +110,7 @@ function testCmdHelper(t, TestServiceManager, test, MockMinkelite) {
         service.instances.findById('1', function(err, instance) {
           tt.ifError(err, 'Default instance should be found');
 
-          test(tt, service, instance, port, server);
+          callback(tt, service, instance, port, server);
           tt.end();
         });
       });

--- a/test/test-instance-profiling.js
+++ b/test/test-instance-profiling.js
@@ -1,4 +1,6 @@
 /* eslint max-nested-callbacks:0 */
+
+var debug = require('debug')('strong-mesh-models:test');
 var test = require('tap').test;
 var util = require('util');
 var fs = require('fs');
@@ -19,29 +21,54 @@ test('Check heap and cpu profiling populates Profile models', function(t) {
     TestServiceManager.prototype.onCtlRequest = onCtlRequest;
 
     testCmdHelper(t, TestServiceManager, function(t, service, instance) {
-      t.test('heap snapshot', function(tt) {
+
+      t.test('heap snapshot download', function(tt) {
         instance.processes({where: {id: 1}}, function(err, processes) {
           tt.ifError(err, 'process lookup should succeed');
           tt.equal(processes.length, 1, 'one process should be found');
 
           var process = processes[0];
 
-          if (!process)
-            return tt.end();
-
           process.heapSnapshot(function(err, res) {
             tt.ifError(err, 'Command should not return error');
             tt.ok(res.profileId, 'Profile ID should be available');
             service.profileDatas.findById(res.profileId, function(err, p) {
-              tt.ok(!err, 'Profile lookup should not return error');
+              tt.ifError(err, 'Profile lookup should not return error');
               tt.ok(p, 'Profile object should exist');
-              fs.writeFileSync(p.fileName, 'test heapsnapshot');
               instance.downloadProfile(p.id, function(err, res) {
                 tt.ok(!err, 'Profile download should not error');
                 res.setEncoding('utf8');
                 res.on('data', function(s) {
-                  tt.equal(s, 'test heapsnapshot', 'Snapshot should match');
+                  tt.equal(s, 'PROFILE', 'Snapshot should match');
                   tt.end();
+                });
+              });
+            });
+          });
+        });
+      });
+
+      t.test('heap snapshot delete', function(tt) {
+        instance.processes({where: {id: 1}}, function(err, processes) {
+          tt.ifError(err);
+
+          processes[0].heapSnapshot(function(err, res) {
+            tt.ifError(err);
+
+            service.profileDatas.findById(res.profileId, function(err, p) {
+              tt.ifError(err);
+
+              fs.readFile(p.fileName, 'utf-8', function(err, data) {
+                tt.ifError(err);
+                tt.equal(data, 'PROFILE');
+
+                p.constructor.deleteById(p.id, function(err) {
+                  tt.ifError(err);
+                  fs.readFile(p.fileName, function(err) {
+                    debug('%j should be deleted: %s', p.fileName, err);
+                    tt.ok(err);
+                    tt.end();
+                  });
                 });
               });
             });


### PR DESCRIPTION
When ProfileData instance is deleted, also delete the profile file on
disk.

connected to strongloop-internal/scrum-nodeops#725

