### PR TITLE
meshadm: default command is exec-list

### DIFF
--- a/bin/sl-meshadm.js
+++ b/bin/sl-meshadm.js
@@ -34,7 +34,7 @@ var apiUrl = process.env.STRONGLOOP_MESH_API ||
   process.env.STRONGLOOP_PM ||
   'http://127.0.0.1:8701';
 
-var command = 'status';
+var command = 'exec-list';
 var option;
 while ((option = parser.getopt()) !== undefined) {
   switch (option.option) {


### PR DESCRIPTION
connected to fix strongloop-internal/scrum-nodeops#804


