### PR TITLE
fix regression in process hooks

### DIFF
--- a/server/models/service-process.js
+++ b/server/models/service-process.js
@@ -46,7 +46,9 @@ module.exports = function extendServiceProcess(ServiceProcess) {
           stopReason: pInfo.reason,
         }, function(err, proc) {
           if (err) return asyncCb(err);
-          serviceManager.onProcessExit(proc, asyncCb);
+          serviceManager.onProcessExit(proc, function(err) {
+            return asyncCb(err, proc);
+          });
         });
       }
       // Found proc, but it was stopped, so nothing to do.
@@ -78,7 +80,9 @@ module.exports = function extendServiceProcess(ServiceProcess) {
     ], function ensureSave(err, proc) {
       debug('on exit of %j, save Process: %j', pInfo, err || proc);
       if (err) return callback(err);
-      serviceManager.onProcessExit(proc, callback);
+      serviceManager.onProcessExit(proc, function(err) {
+        return callback(err, proc);
+      });
     });
   }
   ServiceProcess.recordExit = recordExit;
@@ -102,7 +106,9 @@ module.exports = function extendServiceProcess(ServiceProcess) {
     ], function ensureSave(err, proc) {
       debug('Listening of %j, save Process: %j', pInfo, err || proc);
       if (err) return callback(err);
-      serviceManager.onProcessListen(proc, callback);
+      serviceManager.onProcessListen(proc, function(err) {
+        return callback(err, proc);
+      });
     });
   }
   ServiceProcess.recordListeningEndpoint = recordListeningEndpoint;

--- a/test/meshctl-helper.js
+++ b/test/meshctl-helper.js
@@ -120,6 +120,8 @@ function testCmdHelper(t, TestServiceManager, callback, MockMinkelite) {
       server.stop(tt.end.bind(tt));
     });
 
+    t.end();
+
   });
 }
 

--- a/test/test-service-external-db.js
+++ b/test/test-service-external-db.js
@@ -38,5 +38,7 @@ test('Service environment variable manipulation', function(t) {
       server.stop();
       tt.end();
     });
+
+    t.end();
   });
 });


### PR DESCRIPTION
New hooks were injected into the process update chain in f4cbe6a674ab1e3a96f24ef2b848238cc3ac29aa but the default implementations did not forward their results, breaking things.