### PR TITLE
Add dbWatch template hooks to server models

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -150,7 +150,8 @@ Client.prototype.serviceList = serviceList;
 function serviceDestroy(nameOrId, callback) {
   var Service = this.models.ServerService;
 
-  var q = {where: {or: [{name: nameOrId}, {id: nameOrId}]}};
+  var q = (typeof nameOrId === 'string') ?
+      {wherer: {name: nameOrId}} : {where: {id: nameOrId}};
   Service.findOne(q, function(err, service) {
     if (err || !service) return callback(err, service);
 

--- a/server/boot/extend-models.js
+++ b/server/boot/extend-models.js
@@ -1,25 +1,29 @@
-var async = require('async');
+'use strict';
+
 var agentTrace = require('../models/agent-trace');
 var Api = require('../models/api');
+var async = require('async');
 var executor = require('../models/executor');
 var expressUsageRecord = require('../models/express-usage-record');
 var gateway = require('../models/gateway');
 var profileData = require('../models/profile-data');
-var serverService = require('../models/server-service');
 var serviceInstance = require('../models/service-instance');
 var serviceMetric = require('../models/service-metric');
 var serviceProcess = require('../models/service-process');
+var serverService = require('../models/server-service');
 
 module.exports = function(server) {
   Api(server.models.Api);
   agentTrace(server.models.AgentTrace);
   executor(server.models.Executor);
   expressUsageRecord(server.models.ExpressUsageRecord);
+  gateway(server.models.Gateway);
   profileData(server.models.ProfileData);
   serviceInstance(server.models.ServiceInstance);
   serviceMetric(server.models.ServiceMetric);
   serviceProcess(server.models.ServiceProcess);
-  gateway(server.models.Gateway);
+  serverService(server.models.ServerService);
+
   var modelsToWatch = [
     {name: 'agenttrace', instance: agentTrace},
     {name: 'executor', instance: executor},

--- a/server/boot/extend-models.js
+++ b/server/boot/extend-models.js
@@ -1,9 +1,11 @@
+var async = require('async');
 var agentTrace = require('../models/agent-trace');
 var Api = require('../models/api');
 var executor = require('../models/executor');
 var expressUsageRecord = require('../models/express-usage-record');
 var gateway = require('../models/gateway');
 var profileData = require('../models/profile-data');
+var serverService = require('../models/server-service');
 var serviceInstance = require('../models/service-instance');
 var serviceMetric = require('../models/service-metric');
 var serviceProcess = require('../models/service-process');
@@ -18,4 +20,27 @@ module.exports = function(server) {
   serviceMetric(server.models.ServiceMetric);
   serviceProcess(server.models.ServiceProcess);
   gateway(server.models.Gateway);
+  var modelsToWatch = [
+    {name: 'agenttrace', instance: agentTrace},
+    {name: 'executor', instance: executor},
+    {name: 'expressusagerecord', instance: expressUsageRecord},
+    {name: 'profiledata', instance: profileData},
+    {name: 'serviceinstance', instance: serviceInstance},
+    {name: 'serverservice', instance: serverService},
+    {name: 'servicenetric', instance: serviceMetric},
+    {name: 'serviceprocess', instance: serviceProcess},
+    {name: 'gateway', instance: gateway},
+  ];
+  server.on('ready', function(dbWatcher) {
+    async.eachSeries(modelsToWatch, function(model, callback) {
+      if (model.instance.modelWatcher) {
+        dbWatcher.on(model.name, model.instance.modelWatcher);
+        dbWatcher.watchTable(model.name, function(err) {
+          callback(err);
+        });
+      } else {
+        callback();
+      }
+    });
+  });
 };

--- a/server/models/agent-trace.js
+++ b/server/models/agent-trace.js
@@ -2,7 +2,14 @@ var async = require('async');
 var debug = require('debug')('strong-mesh-models:server:agent-trace');
 var deleteOld = require('./delete-old');
 
-module.exports = function extendAgentTrace(AgentTrace) {
+exports = module.exports = extendAgentTrace;
+exports.modelWatcher = modelWatcher;
+
+function modelWatcher(msg) {
+  console.log('------------------------ agenttrace:', msg);
+}
+
+function extendAgentTrace(AgentTrace) {
   function recordTrace(instanceId, req, callback) {
     debug('trace data: %j', req.trace);
     var ServiceProcess = AgentTrace.app.models.ServiceProcess;
@@ -40,4 +47,4 @@ module.exports = function extendAgentTrace(AgentTrace) {
     });
   }
   AgentTrace.recordTrace = recordTrace;
-};
+}

--- a/server/models/executor.js
+++ b/server/models/executor.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var async = require('async');
 
 exports = module.exports = extendExecutor;

--- a/server/models/executor.js
+++ b/server/models/executor.js
@@ -1,6 +1,13 @@
 var async = require('async');
 
-module.exports = function(Executor) {
+exports = module.exports = extendExecutor;
+exports.modelWatcher = modelWatcher;
+
+function modelWatcher(msg) {
+  console.log('------------------------ executor:', msg);
+}
+
+function extendExecutor(Executor) {
 
   // Refer to server-service.js for description of instance vs currentInstance
   // vs data.
@@ -51,4 +58,4 @@ module.exports = function(Executor) {
     Executor.app.serviceManager.onExecutorRequest(
       this.id, {cmd: 'shutdown'}, callback);
   };
-};
+}

--- a/server/models/express-usage-record.js
+++ b/server/models/express-usage-record.js
@@ -2,7 +2,14 @@ var debug = require('debug')('strong-mesh-models:server:express-usage');
 var deleteOld = require('./delete-old');
 var url = require('url');
 
-module.exports = function extendExpressUsageRecord(ExpressUsageRecord) {
+exports = module.exports = extendExpressUsageRecord;
+exports.modelWatcher = modelWatcher;
+
+function modelWatcher(msg) {
+  console.log('------------------------ expressusagerecord:', msg);
+}
+
+function extendExpressUsageRecord(ExpressUsageRecord) {
   function recordUsage(instanceId, req, callback) {
     debug('Express usage record: %j', req.record);
     var ServiceProcess = ExpressUsageRecord.app.models.ServiceProcess;
@@ -148,4 +155,4 @@ module.exports = function extendExpressUsageRecord(ExpressUsageRecord) {
     ExpressUsageRecord.find(q, callback);
   }
   ExpressUsageRecord.endpointDetail = endpointDetail;
-};
+}

--- a/server/models/express-usage-record.js
+++ b/server/models/express-usage-record.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var debug = require('debug')('strong-mesh-models:server:express-usage');
 var deleteOld = require('./delete-old');
 var url = require('url');

--- a/server/models/gateway.js
+++ b/server/models/gateway.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var async = require('async');
 
 exports = module.exports = extendGateway;

--- a/server/models/gateway.js
+++ b/server/models/gateway.js
@@ -1,6 +1,13 @@
 var async = require('async');
 
-module.exports = function extendGateway(Gateway) {
+exports = module.exports = extendGateway;
+exports.modelWatcher = modelWatcher;
+
+function modelWatcher(msg) {
+  console.log('------------------------ gateway:', msg);
+}
+
+function extendGateway(Gateway) {
   // Refer to server-service.js for description of instance vs currentInstance
   // vs data.
 
@@ -37,4 +44,4 @@ module.exports = function extendGateway(Gateway) {
       );
     });
   });
-};
+}

--- a/server/models/profile-data.js
+++ b/server/models/profile-data.js
@@ -6,7 +6,14 @@ var fmt = require('util').format;
 var fs = require('fs');
 var path = require('path');
 
-module.exports = function extendProfileData(ProfileData) {
+exports = module.exports = extendProfileData;
+exports.modelWatcher = modelWatcher;
+
+function modelWatcher(msg) {
+  console.log('------------------------ profiledata:', msg);
+}
+
+function extendProfileData(ProfileData) {
   // If a ProfileData has a fileName, ensure it is deleted from disk before the
   // ProfileData is deleted.
   ProfileData.observe('before delete', function(ctx, next) {
@@ -123,4 +130,4 @@ module.exports = function extendProfileData(ProfileData) {
   }
 
   ProfileData.recordProfileData = recordProfileData;
-};
+}

--- a/server/models/server-service.js
+++ b/server/models/server-service.js
@@ -1,7 +1,9 @@
+'use strict';
+
 var async = require('async');
 var debug = require('debug')('strong-mesh-models:server:server-service');
-var fs = require('fs');
 var fmt = require('util').format;
+var fs = require('fs');
 
 exports = module.exports = extendServerService;
 exports.modelWatcher = modelWatcher;

--- a/server/models/server-service.js
+++ b/server/models/server-service.js
@@ -3,7 +3,14 @@ var debug = require('debug')('strong-mesh-models:server:server-service');
 var fs = require('fs');
 var fmt = require('util').format;
 
-module.exports = function extendServerService(ServerService) {
+exports = module.exports = extendServerService;
+exports.modelWatcher = modelWatcher;
+
+function modelWatcher(msg) {
+  console.log('------------------------ serverservice:', msg);
+}
+
+function extendServerService(ServerService) {
   ServerService.disableRemoteMethod('upsert', true);
   ServerService.disableRemoteMethod('updateAll', true);
 
@@ -242,4 +249,4 @@ module.exports = function extendServerService(ServerService) {
     });
   }
   ServerService.prototype._callOnInstances = _callOnInstances;
-};
+}

--- a/server/models/service-instance.js
+++ b/server/models/service-instance.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var async = require('async');
 var debug = require('debug')('strong-mesh-models:server:service-instance');
 var fmt = require('util').format;

--- a/server/models/service-instance.js
+++ b/server/models/service-instance.js
@@ -2,7 +2,14 @@ var async = require('async');
 var debug = require('debug')('strong-mesh-models:server:service-instance');
 var fmt = require('util').format;
 
-module.exports = function extendServiceInstance(ServiceInstance) {
+exports = module.exports = extendServiceInstance;
+exports.modelWatcher = modelWatcher;
+
+function modelWatcher(msg) {
+  console.log('------------------------ serviceinstance:', msg);
+}
+
+function extendServiceInstance(ServiceInstance) {
   ServiceInstance.beforeRemote(
     'prototype.updateAttributes',
     function(ctx, _, next) {
@@ -326,4 +333,4 @@ module.exports = function extendServiceInstance(ServiceInstance) {
   ServiceInstance.disableRemoteMethod('upsert', true);
   ServiceInstance.disableRemoteMethod('deleteById', true);
   ServiceInstance.disableRemoteMethod('deleteAll', true);
-};
+}

--- a/server/models/service-metric.js
+++ b/server/models/service-metric.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var async = require('async');
 var debug = require('debug')('strong-mesh-models:server:service-metric');
 var deleteOld = require('./delete-old');

--- a/server/models/service-metric.js
+++ b/server/models/service-metric.js
@@ -2,7 +2,14 @@ var async = require('async');
 var debug = require('debug')('strong-mesh-models:server:service-metric');
 var deleteOld = require('./delete-old');
 
-module.exports = function extendServiceMetric(ServiceMetric) {
+exports = module.exports = extendServiceMetric;
+exports.modelWatcher = modelWatcher;
+
+function modelWatcher(msg) {
+  console.log('------------------------ servicemetric:', msg);
+}
+
+function extendServiceMetric(ServiceMetric) {
   function recordMetrics(instanceId, req, callback) {
     debug('Process metrics: %j', req.metrics);
     var ServiceProcess = ServiceMetric.app.models.ServiceProcess;
@@ -38,4 +45,4 @@ module.exports = function extendServiceMetric(ServiceMetric) {
     );
   }
   ServiceMetric.recordMetrics = recordMetrics;
-};
+}

--- a/server/models/service-process.js
+++ b/server/models/service-process.js
@@ -2,7 +2,14 @@ var async = require('async');
 var debug = require('debug')('strong-mesh-models:server:service-process');
 var fmt = require('util').format;
 
-module.exports = function extendServiceProcess(ServiceProcess) {
+exports = module.exports = extendServiceProcess;
+exports.modelWatcher = modelWatcher;
+
+function modelWatcher(msg) {
+  console.log('------------------------ serviceprocess:', msg);
+}
+
+function extendServiceProcess(ServiceProcess) {
   function recordFork(instanceId, pInfo, callback) {
     debug('Process forked: worker id %d pid %d ppid %d pst %d',
       pInfo.wid, pInfo.pid, pInfo.ppid, pInfo.pst || pInfo.startTime);
@@ -390,4 +397,4 @@ module.exports = function extendServiceProcess(ServiceProcess) {
     );
   }
   ServiceProcess.prototype.applyPatch = applyPatch;
-};
+}

--- a/test/test-instance-create-destroy.js
+++ b/test/test-instance-create-destroy.js
@@ -55,7 +55,7 @@ test('Create and destroy instances', function(t) {
   }
   TestServiceManager.prototype.onInstanceDestroy = onInstanceDestroy;
 
-  t.plan(13);
+  t.plan(20);
   var server = meshServer(new TestServiceManager());
   server.set('port', 0);
   server.start(function(err, port) {


### PR DESCRIPTION
Template dbWatcher hooks added to server models for initial end-to-end testing.  Existing loopback connector based notification is still intact.
