### PR TITLE
Debugger control channel

### DIFF
--- a/bin/sl-meshctl.js
+++ b/bin/sl-meshctl.js
@@ -241,7 +241,7 @@ function printServiceStatus(service, callback) {
 
     var processTable = [
       ['  ', 'ID', 'PID', 'WID', 'Listening Ports',
-          'Tracking objects?', 'CPU profiling?', 'Tracing?']
+          'Tracking objects?', 'CPU profiling?', 'Tracing?', 'Debugging?']
     ];
     if (verbose)
       processTable[0].push('Stop reason', 'Stop time');
@@ -260,6 +260,7 @@ function printServiceStatus(service, callback) {
         proc.isTrackingObjects ? 'yes' : '',
         profiling(proc),
         proc.isTracing ? 'yes' : '',
+        proc.debugger && proc.debugger.running ? 'yes' : '',
       ];
       if (verbose)
         procEntry.push(proc.stopReason, proc.stopTime || '');

--- a/bin/sl-meshctl.js
+++ b/bin/sl-meshctl.js
@@ -131,6 +131,8 @@ function runCommand(client, command) {
     'get-process-count': cmdGetProcessCount, // No docs, internal use only.
     'log-dump': cmdLogDump,
     'shutdown': cmdShutdown,
+    'dbg-start': cmdDebuggerStart,
+    'dbg-stop': cmdDebuggerStop,
   }[command] || unknown)(client);
 }
 
@@ -755,6 +757,38 @@ function download(instance, profileId, file, callback) {
       }
     }
   });
+}
+
+function cmdDebuggerStart(client) {
+  var target = mandatory('target');
+
+  client.resolveTarget(target,
+    function(err, service, executor, instance, process) {
+      dieIf(err);
+      process.startDebugger(function(err, response) {
+          dieIf(err);
+          debug('startDebugger: %j', response);
+          console.log('Debugger listening on port %s.', response.port);
+        }
+      );
+    }
+  );
+}
+
+function cmdDebuggerStop(client) {
+  var target = mandatory('target');
+
+  client.resolveTarget(target,
+    function(err, service, executor, instance, process) {
+      dieIf(err);
+      process.stopDebugger(function(err, response) {
+          dieIf(err);
+          debug('stopDebugger: %j', response);
+          console.log('Debugger was disabled.', response.port);
+        }
+      );
+    }
+  );
 }
 
 function mandatory(name) {

--- a/bin/sl-meshctl.txt
+++ b/bin/sl-meshctl.txt
@@ -127,3 +127,7 @@ command.
         that the `--metrics=URL` option is passed to the runner.
 
   patch WRK FILE           Apply patch FILE to worker WRK.
+
+  dbg-start WRK            Enable DevTools Debugger backend in worker WRK.
+
+  dbg-stop WRK             Disable DevTools Debugger backend in worker WRK.

--- a/common/models/service-process.js
+++ b/common/models/service-process.js
@@ -160,4 +160,26 @@ module.exports = function extendServiceProcess(ServiceProcess) {
       description: 'Take a snapshot of the HEAP for a process.'
     }
   );
+
+  ServiceProcess.remoteMethod(
+    'startDebugger',
+    {
+      http: {path: '/debugger/start', verb: 'post'},
+      isStatic: false,
+      accepts: [],
+      returns: {arg: 'response', type: 'object', root: true},
+      description: 'Start DevTools Debugger backend on a worker.'
+    }
+  );
+
+  ServiceProcess.remoteMethod(
+    'stopDebugger',
+    {
+      http: {path: '/debugger/stop', verb: 'post'},
+      isStatic: false,
+      accepts: [],
+      returns: {arg: 'response', type: 'object', root: true},
+      description: 'Stop DevTools Debugger backend on a worker.'
+    }
+  );
 };

--- a/common/models/service-process.json
+++ b/common/models/service-process.json
@@ -45,6 +45,11 @@
       "default": false,
       "description": "Indicates if tracing is turned on for this process"
     },
+    "debugger": {
+      "type": { "running": "boolean", "port": "number" },
+      "default": { "running": false, "port": null },
+      "description": "Status of DevTools Debugger in this process"
+    },
     "watchdogTimeout": {
       "type": "number",
       "default": 0,

--- a/server/models/service-process.js
+++ b/server/models/service-process.js
@@ -418,4 +418,28 @@ module.exports = function extendServiceProcess(ServiceProcess) {
     );
   }
   ServiceProcess.prototype.stopDebugger = stopDebugger;
+
+  function recordDebuggerStatusUpdate(instanceId, pInfo, callback) {
+    function updateDebuggerStatus(proc, next) {
+      if (!proc)
+        return next(Error(
+          fmt('Process state update for unknown process: %j', pInfo)));
+
+      proc.updateAttributes({
+        debugger: {
+          running: pInfo.running,
+          port: pInfo.port
+        }
+      }, next);
+    }
+
+    return async.waterfall([
+      _findProcess(instanceId, +pInfo.wid, pInfo.pid, +pInfo.pst),
+      updateDebuggerStatus
+    ], function(err, proc) {
+      debug('Process entry updated: %j', err || proc);
+      callback(err);
+    });
+  }
+  ServiceProcess.recordDebuggerStatusUpdate = recordDebuggerStatusUpdate;
 };

--- a/server/models/service-process.js
+++ b/server/models/service-process.js
@@ -390,4 +390,32 @@ module.exports = function extendServiceProcess(ServiceProcess) {
     );
   }
   ServiceProcess.prototype.applyPatch = applyPatch;
+
+  /**
+   * Start DevTools Debugger backend on a worker.
+   *
+   * @param {function} callback Callback function.
+   */
+  function startDebugger(callback) {
+    this._appCommand({
+        cmd: 'dbg-start',
+        target: this.pid,
+      }, callback
+    );
+  }
+  ServiceProcess.prototype.startDebugger = startDebugger;
+
+  /**
+   * Stop DevTools Debugger backend on a worker.
+   *
+   * @param {function} callback Callback function.
+   */
+  function stopDebugger(callback) {
+    this._appCommand({
+        cmd: 'dbg-stop',
+        target: this.pid,
+      }, callback
+    );
+  }
+  ServiceProcess.prototype.stopDebugger = stopDebugger;
 };

--- a/server/server.js
+++ b/server/server.js
@@ -162,6 +162,9 @@ function server(serviceManager, minkelite, options) {
           ServiceInstance.recordStatusWdUpdate(instanceId, uInfo, callback);
         });
         break;
+      case 'debugger-status':
+        ServiceProcess.recordDebuggerStatusUpdate(instanceId, uInfo, callback);
+        break;
       default:
         debug('Unknown request: %j', uInfo);
         callback();

--- a/test/test-meshctl-debugger.js
+++ b/test/test-meshctl-debugger.js
@@ -1,0 +1,78 @@
+var ServiceManager = require('../index').ServiceManager;
+var assert = require('assert');
+var exec = require('./exec-meshctl');
+var test = require('tap').test;
+var testCmdHelper = require('./meshctl-helper');
+var util = require('util');
+
+test('Test cpu-profiling commands', function(t) {
+  function TestServiceManager() {
+  }
+  util.inherits(TestServiceManager, ServiceManager);
+
+  testCmdHelper(t, TestServiceManager, function(t, service, instance, port) {
+    t.test('Setup service manager (start debugger)', function(tt) {
+      function onCtlRequest(s, i, req, callback) {
+        assert.deepEqual(req, {
+          cmd: 'current', sub: 'dbg-start',
+          target: 1231
+        });
+        callback(null, {port: 12345});
+      }
+      TestServiceManager.prototype.onCtlRequest = onCtlRequest;
+      tt.end();
+    });
+
+    t.test('Start debugger API', function(tt) {
+      instance.processes({where: {pid: 1231}}, function(err, proc) {
+        tt.ifError(err, 'call should not error');
+        proc = proc[0];
+        proc.startDebugger(function(err, status) {
+          tt.ifError(err, 'call should not error');
+          tt.deepEqual(status, {port: 12345});
+          tt.end();
+        });
+      });
+    });
+
+    t.test('Start debugger CLI', function(tt) {
+      exec.resetHome();
+      exec(port, 'dbg-start 1', function(err, stdout) {
+        tt.ifError(err, 'command should not error');
+        tt.match(stdout, /Debugger listening on port \d+/);
+        tt.end();
+      });
+    });
+
+    t.test('Setup service manager (stop debugger)', function(tt) {
+      function onCtlRequest(s, i, req, callback) {
+        assert.equal(req.cmd, 'current');
+        assert.equal(req.sub, 'dbg-stop');
+        assert.equal(req.target, 1231);
+        callback(null, {profile: 'some data'});
+      }
+      TestServiceManager.prototype.onCtlRequest = onCtlRequest;
+      tt.end();
+    });
+
+    t.test('Stop debugger API', function(tt) {
+      instance.processes({where: {pid: 1231}}, function(err, proc) {
+        tt.ifError(err, 'call should not error');
+        proc = proc[0];
+        proc.stopDebugger(function(err /*, status*/) {
+          tt.ifError(err, 'call should not error');
+          tt.end();
+        });
+      });
+    });
+
+    t.test('Stop debugger CLI', function(tt) {
+      exec.resetHome();
+      exec(port, 'dbg-stop 1', function(err, stdout) {
+        tt.ifError(err, 'command should not error');
+        tt.match(stdout, /Debugger was disabled/);
+        tt.end();
+      });
+    });
+  });
+});

--- a/test/test-meshctl-status.js
+++ b/test/test-meshctl-status.js
@@ -39,7 +39,7 @@ test('Test status command', function(t) {
     '    Version  Agent version  Cluster size  Driver metadata',
     '     1.2.3       7.8.9            3             N/A',
     'Processes:',
-    '       ID      PID  WID          Listening Ports         Tracking objects?  CPU profiling?  Tracing?',
+    '       ID      PID  WID          Listening Ports         Tracking objects?  CPU profiling?  Tracing?  Debugging?',
     '    1.1.1230  1230   0',
     '    1.1.1231  1231   1   0.0.0.0:4321, unix:some-socket',
     '    1.1.1232  1232   2            0.0.0.0:4321',

--- a/test/test-notification-model-updates.js
+++ b/test/test-notification-model-updates.js
@@ -485,6 +485,30 @@ test('Test notifications', function(t) {
   t.test('Check worker 1 resumed',
     checkWorker1.bind(this, {stopTime: true, stopReason: null}));
 
+  t.test('Notify debugger-status', function(tt) {
+    var notification = {
+      cmd: 'debugger-status',
+      pid: 1235,
+      wid: 1,
+      running: true,
+      port: 12345
+    };
+    app.handleModelUpdate(1, notification, function(err) {
+      tt.ifError(err);
+
+      var q = {where: {workerId: 1, serviceInstanceId: 1}};
+      app.models.ServiceProcess.find(q, function(err, list) {
+        tt.ifError(err);
+        tt.equal(list.length, 1, 'only one process should be found');
+        var proc = list[0] || {};
+        // NOTE(bajtos) the actual instance contains extra internal properties,
+        // e.g. __data, __persisted, etc.
+        tt.match(proc.debugger, {running: true, port: 12345});
+        tt.end();
+      });
+    });
+  });
+
   t.test('shutdown', function(tt) {
     app.stop();
     tt.end();


### PR DESCRIPTION
Add debugger control commands

 - ServiceProcess:
  - `startDebugger(cb)` at `POST /debugger/start`
  - `stopDebugger(cb)` at `POST /debugger/stop`

 - `bin/sl-meshctl`
  - `dbg-start WRK`
  - `dbg-stop WRK`

Intercept `debugger-status` notifications from strong-supervisor and update the property "ServiceProcess.debugger" with the debugger status.

Add a new per-worker column "Debugging" to sl-pmctl status output

See the [spike blog post](https://docs.google.com/document/d/1hPuuKQ3GCLKCUaQaNxuwyRqOfcI_tnqy5TLGLLdWHeM/edit) for a high-level architectural overview.

Connect to strongloop-internal/scrum-loopback#261

/to @kraman please review
/cc @sam-github 
