### PR TITLE
sl-meshctl: fix stdout message on dbg-stop

### DIFF
--- a/bin/sl-meshctl.js
+++ b/bin/sl-meshctl.js
@@ -787,7 +787,7 @@ function cmdDebuggerStop(client) {
       instance.stopDebugger(process.id, function(err, response) {
           dieIf(err);
           debug('stopDebugger: %j', response);
-          console.log('Debugger was disabled.', response.port);
+          console.log('Debugger was disabled.');
         }
       );
     }


### PR DESCRIPTION
Remove extra "undefined" string from the output (introduced by #109).

/cc @kraman FYI, I think this fix does not require a review.