### PR TITLE
make InstanceActions ephemeral

### DIFF
--- a/server/model-config.json
+++ b/server/model-config.json
@@ -72,7 +72,7 @@
     "public": false
   },
   "InstanceAction": {
-    "dataSource": "db",
+    "dataSource": "memory",
     "public": false
   }
 }

--- a/server/models/instance-action.js
+++ b/server/models/instance-action.js
@@ -6,6 +6,14 @@ var path = require('path');
 var util = require('util');
 
 module.exports = function extendInstanceAction(InstanceAction) {
+  InstanceAction.observe('after save', function(ctx, next) {
+    // There is no reason to keep these instances around. Until we transition
+    // away from them entirely we'll just auto-expire them.
+    if (ctx.instance && ctx.isNewInstance) {
+      setTimeout(ctx.instance.destroy.bind(ctx.instance), 10 * 1000).unref();
+    }
+    next();
+  });
   InstanceAction.observe('before save', function(ctx, next) {
     if (!ctx.instance) return next();
     var now = Date.now();


### PR DESCRIPTION
Instead of persisting them to disk and waiting for that persistence to
finish before handing back the result, just use the memory connector.

Furthermore, there isn't any reason to keep them around at all, so for
the immediate future we can use a simple 10s expiration so that the
instances can GC themselves instead of just accumulating in memory
indefinitely.

This is a forward port of #115 to master.