### PR TITLE
Make tests pass on Windows

### DIFF
--- a/test/test-client-version-mismatch.js
+++ b/test/test-client-version-mismatch.js
@@ -25,7 +25,7 @@ test('check non-matching version', function(tt) {
     var client = new Client('http://127.0.0.1:' + port + '/api');
     client.checkRemoteApiSemver(function(err) {
       tt.assert(err, 'should mismatch');
-      tt.assert(/incompatible.*5.1.1/.test(err.message), err.message);
+      tt.match(err.message, /incompatible.*5.1.1/);
       server.stop(function() {
         tt.end();
       });

--- a/test/test-load-models.js
+++ b/test/test-load-models.js
@@ -10,12 +10,12 @@ test('load models', function(t) {
   }
 
   app.once('error', function(err) {
-    t.assert(!err, 'App should start succesfully');
+    t.ifErr(err, 'App should start succesfully');
     end();
   });
 
   app.once('started', function() {
-    t.assert(true, 'Models should be loaded without errors');
+    t.pass('Models should be loaded without errors');
 
     var Service = app.models.ServerService;
     var s = new Service({
@@ -23,7 +23,7 @@ test('load models', function(t) {
     });
     s.save(function(err, savedService) {
       console.log(savedService);
-      t.assert(!err, 'service save should not error');
+      t.ifErr(err, 'service save should not error');
       end();
     });
   });

--- a/test/test-meshctl-cpu-profiling.js
+++ b/test/test-meshctl-cpu-profiling.js
@@ -116,7 +116,7 @@ test('Test cpu-profiling commands', function(t) {
       exec(port, 'cpu-start 3', function(err, stdout, stderr) {
         tt.ok(err, 'command should error');
         var patt = /Command "cpu-start" on "\S+" failed with Error: something/;
-        tt.assert(patt.test(stderr), 'Rendered error should match');
+        tt.match(stderr.toString(), patt, 'Rendered error should match');
         tt.end();
       });
     });

--- a/test/test-meshctl-env.js
+++ b/test/test-meshctl-env.js
@@ -31,7 +31,7 @@ test('Test env commands', function(t) {
     t.test('env-set API', function(tt) {
       service.setEnvs({A: 1, B: 2}, function(err, response) {
         tt.ifError(err, 'call should not error');
-        assert.deepEqual(response, {A: 1, B: 2});
+        tt.deepEqual(response, {A: 1, B: 2});
         tt.end();
       });
     });
@@ -112,7 +112,7 @@ test('Test env commands', function(t) {
       exec(port, 'env-set 1 A=1 B=2', function(err, stdout, stderr) {
         tt.ok(err, 'command should error');
         var patt = /Command "env-set" on "\S+" failed with Error: bad stuff/;
-        tt.assert(patt.test(stderr), 'Rendered error should match');
+        tt.match(stderr.toString(), patt, 'Rendered error should match');
         tt.end();
       });
     });
@@ -122,7 +122,7 @@ test('Test env commands', function(t) {
       exec(port, 'env-unset 1 C', function(err, stdout, stderr) {
         tt.ok(err, 'command should error');
         var patt = /Command "env-unset" on "\S+" failed with Error: bad stuff/;
-        tt.assert(patt.test(stderr), 'Rendered error should match');
+        tt.match(stderr.toString(), patt, 'Rendered error should match');
         tt.end();
       });
     });

--- a/test/test-meshctl-heap-snapshot.js
+++ b/test/test-meshctl-heap-snapshot.js
@@ -82,7 +82,7 @@ test('Test heap-snapshot commands', function(t) {
       exec(port, 'heap-snapshot 2', function(err, stdout, stderr) {
         tt.ok(err, 'command should error');
         var patt = /Command "heap-snapshot" on "\S+" failed with Error:.+500/;
-        tt.assert(patt.test(stderr), 'Rendered error should match');
+        tt.match(stderr.toString(), patt, 'Rendered error should match');
         tt.end();
       });
     });

--- a/test/test-meshctl-logdump.js
+++ b/test/test-meshctl-logdump.js
@@ -58,7 +58,7 @@ test('Test log-dump command', function(t) {
           'line 4 line 4 line 4 line 4\n',
           'log should match');
         var patt = /Command "log-dump" on "\S+" failed with done/;
-        tt.assert(patt.test(stderr), 'Rendered error should match');
+        tt.match(stderr.toString(), patt, 'Rendered error should match');
         tt.end();
       });
     });

--- a/test/test-meshctl-npmls.js
+++ b/test/test-meshctl-npmls.js
@@ -80,7 +80,7 @@ test('Test ls command', function(t) {
       exec(port, 'npmls 1', function(err, stdout, stderr) {
         tt.ok(err, 'command should error');
         var patt = /Command "npmls" on "\S+" failed with Error: no app /;
-        tt.assert(patt.test(stderr), 'Rendered error should match');
+        tt.match(stderr.toString(), patt, 'Rendered error should match');
         tt.end();
       });
     });

--- a/test/test-meshctl-object-tracking.js
+++ b/test/test-meshctl-object-tracking.js
@@ -103,7 +103,7 @@ test('Test object-tracking commands', function(t) {
       exec(port, 'objects-start 3', function(err, stdout, stderr) {
         tt.ok(err, 'command should error');
         var patt = /Command "objects-start" on "\S+" failed with Error: Unable/;
-        tt.assert(patt.test(stderr), 'Rendered error should match');
+        tt.match(stderr.toString(), patt, 'Rendered error should match');
         tt.end();
       });
     });

--- a/test/test-meshctl-patch.js
+++ b/test/test-meshctl-patch.js
@@ -81,7 +81,7 @@ test('Test patch commands', function(t) {
       exec(port, 'patch 1 patch.file', function(err, stdout, stderr) {
         tt.ok(err, 'command should error');
         var patt = /Command "patch" on "\S+" failed with Error: some error/;
-        tt.assert(patt.test(stderr), 'Rendered error should match');
+        tt.match(stderr.toString(), patt, 'Rendered error should match');
         tt.end();
       });
     });

--- a/test/test-meshctl-restart.js
+++ b/test/test-meshctl-restart.js
@@ -120,7 +120,7 @@ test('Test restart command', function(t) {
       exec(port, 'restart 1', function(err, stdout, stderr) {
         tt.ok(err, 'command should error');
         var patt = /Command "restart" on "\S+" failed with error/;
-        tt.assert(patt.test(stderr), 'Rendered error should match');
+        tt.match(stderr.toString(), patt, 'Rendered error should match');
         tt.end();
       });
     });

--- a/test/test-meshctl-ssh2.js
+++ b/test/test-meshctl-ssh2.js
@@ -5,8 +5,11 @@ var testCmdHelper = require('./meshctl-helper');
 var util = require('util');
 var ServiceManager = require('../index').ServiceManager;
 
+var skipOnWindows = {
+  skip: process.platform === 'win32' && 'assuming no ssh server on Windows',
+};
 
-test('Test SSH tunnel', function(t) {
+test('Test SSH tunnel', skipOnWindows, function(t) {
   function TestServiceManager() {
   }
   util.inherits(TestServiceManager, ServiceManager);
@@ -23,8 +26,9 @@ test('Test SSH tunnel', function(t) {
 
     t.test('Start CLI', function(tt) {
       exec.resetHome();
-      exec.withSSH(port, 'start 1', function(err, stdout) {
+      exec.withSSH(port, 'start 1', function(err, stdout, stderr) {
         tt.ifError(err, 'command should not error');
+        tt.comment(stderr);
         tt.equal(stdout, 'Service "service 1" starting...\n',
           'Rendered output should match');
         tt.end();

--- a/test/test-meshctl-start.js
+++ b/test/test-meshctl-start.js
@@ -61,7 +61,7 @@ test('Test start command', function(t) {
       exec(port, 'start 1', function(err, stdout, stderr) {
         tt.ok(err, 'command should error');
         var patt = /Command "start" on "\S+" failed with error/;
-        tt.assert(patt.test(stderr), 'Rendered error should match');
+        tt.match(stderr.toString(), patt, 'Rendered error should match');
         tt.end();
       });
     });

--- a/test/test-meshctl-stop.js
+++ b/test/test-meshctl-stop.js
@@ -91,7 +91,7 @@ test('Test stop command', function(t) {
       exec(port, 'stop 1', function(err, stdout, stderr) {
         tt.ok(err, 'command should error');
         var patt = /Command "stop" on "\S+" failed with error/;
-        tt.assert(patt.test(stderr), 'Rendered error should match');
+        tt.match(stderr.toString(), patt, 'Rendered error should match');
         tt.end();
       });
     });


### PR DESCRIPTION
* Use smarter assertions (`t.match(a, b)` vs `t.assert(b.test(a))`) for improved test debugging.
* Avoid `process.exit()` where possible to ensure stdio is flushed, allowing expected error messages to be seen
* Skip SSH based tests on Windows since it is unlikely to have sshd running locally